### PR TITLE
Added missing QT icon include

### DIFF
--- a/src/qt-gui/AboutDialog.cpp
+++ b/src/qt-gui/AboutDialog.cpp
@@ -3,6 +3,7 @@
 #include <QFile>
 #include <QTextStream>
 #include <QPixmap>
+#include <QIcon>
 
 namespace gui
 {


### PR DESCRIPTION
Adding a missing include which is required for QT 5.15.2.